### PR TITLE
Discover properly negative max values

### DIFF
--- a/Sparklines/src/org/vaadin/sparklines/client/ui/SparklinesGWT.java
+++ b/Sparklines/src/org/vaadin/sparklines/client/ui/SparklinesGWT.java
@@ -41,7 +41,7 @@ public class SparklinesGWT extends Composite {
     protected String pathColor = "#ccc";
     protected int pathWidth = 1;
 
-    protected double max = Double.MIN_VALUE;
+    protected double max = -Double.MAX_VALUE;//Double.MIN_VALUE;
     protected double maxidx = 0;
     protected double minidx = 0;
     protected double min = Double.MAX_VALUE;
@@ -71,7 +71,7 @@ public class SparklinesGWT extends Composite {
     protected String valueColor = "#00f";
 
     public SparklinesGWT(String caption, int graphWidth, int graphHeight,
-            int displayRangeMin, int displayRangeMax) {
+                         int displayRangeMin, int displayRangeMax) {
         this.graphHeight = graphHeight;
         this.graphWidth = graphWidth;
         this.displayHigh = displayRangeMax;
@@ -284,7 +284,7 @@ public class SparklinesGWT extends Composite {
     }
 
     private void redraw() {
-        max = Double.MIN_VALUE;
+        max = Integer.MIN_VALUE;//Double.MIN_VALUE;
         maxidx = 0;
         minidx = 0;
         min = Integer.MAX_VALUE;
@@ -324,9 +324,8 @@ public class SparklinesGWT extends Composite {
         }
         value.setText(String.valueOf(data[data.length - 1]));
 
-        double effectiveMin = (displayLow < Double.MAX_VALUE ? displayLow : min);
-        double effectiveMax = (displayHigh > Double.MIN_VALUE ? displayHigh
-                : max);
+        double effectiveMin = effectiveMin();
+        double effectiveMax = effectiveMax();
 
         if (graphHeight < 1) {
             // canvas.setHeight(effectiveMax - effectiveMin + PAD);
@@ -342,8 +341,7 @@ public class SparklinesGWT extends Composite {
             canvas.setWidth(graphWidth);
         }
 
-        vscale = (double) (canvas.getHeight() - PAD)
-                / (effectiveMax - effectiveMin);
+        vscale = (double) (canvas.getHeight() - PAD) / (effectiveMax - effectiveMin);
         hscale = (double) (canvas.getWidth() - PAD) / (data.length - 1);
 
         // average
@@ -392,9 +390,16 @@ public class SparklinesGWT extends Composite {
 
     }
 
+    private double effectiveMin() {
+        return displayLow < Integer.MAX_VALUE ? displayLow : min;
+    }
+
+    private double effectiveMax() {
+        return displayHigh > Integer.MIN_VALUE ? displayHigh : max;
+    }
+
     private int translateY(double y) {
-        double effectiveMin = (displayLow < Integer.MAX_VALUE ? displayLow
-                : min);
+        double effectiveMin = effectiveMin();
         int newY = (int) ((y - effectiveMin) * vscale);
         int res = (canvas.getHeight() - newY) - OFFSET;
         return res;

--- a/Sparklines/src/org/vaadin/sparklines/client/ui/SparklinesGWT.java
+++ b/Sparklines/src/org/vaadin/sparklines/client/ui/SparklinesGWT.java
@@ -41,7 +41,7 @@ public class SparklinesGWT extends Composite {
     protected String pathColor = "#ccc";
     protected int pathWidth = 1;
 
-    protected double max = -Double.MAX_VALUE;//Double.MIN_VALUE;
+    protected double max = -(Double.MAX_VALUE - 1);
     protected double maxidx = 0;
     protected double minidx = 0;
     protected double min = Double.MAX_VALUE;
@@ -284,7 +284,7 @@ public class SparklinesGWT extends Composite {
     }
 
     private void redraw() {
-        max = Integer.MIN_VALUE;//Double.MIN_VALUE;
+        max = Integer.MIN_VALUE;
         maxidx = 0;
         minidx = 0;
         min = Integer.MAX_VALUE;

--- a/Sparklines/src/org/vaadin/sparklines/client/ui/SparklinesGWT.java
+++ b/Sparklines/src/org/vaadin/sparklines/client/ui/SparklinesGWT.java
@@ -18,7 +18,8 @@ import com.google.gwt.user.client.ui.Label;
 // TODO setDotSize
 // TODO ? set
 public class SparklinesGWT extends Composite {
-
+    private static final double MAXIMAL_VALUE = Double.MAX_VALUE;
+    private static final double MINIMAL_VALUE = -(Double.MAX_VALUE - 1);
     public static String CLASSNAME = "v-sparkline";
 
     private static int PAD = 4;
@@ -41,10 +42,10 @@ public class SparklinesGWT extends Composite {
     protected String pathColor = "#ccc";
     protected int pathWidth = 1;
 
-    protected double max = -(Double.MAX_VALUE - 1);
+    protected double max = MINIMAL_VALUE;
     protected double maxidx = 0;
     protected double minidx = 0;
-    protected double min = Double.MAX_VALUE;
+    protected double min = MAXIMAL_VALUE;
 
     protected int avg = 0;
 
@@ -284,10 +285,10 @@ public class SparklinesGWT extends Composite {
     }
 
     private void redraw() {
-        max = Integer.MIN_VALUE;
+        max = MINIMAL_VALUE;
         maxidx = 0;
         minidx = 0;
-        min = Integer.MAX_VALUE;
+        min = MAXIMAL_VALUE;
 
         avg = 0;
 
@@ -391,11 +392,11 @@ public class SparklinesGWT extends Composite {
     }
 
     private double effectiveMin() {
-        return displayLow < Integer.MAX_VALUE ? displayLow : min;
+        return displayLow < MAXIMAL_VALUE ? displayLow : min;
     }
 
     private double effectiveMax() {
-        return displayHigh > Integer.MIN_VALUE ? displayHigh : max;
+        return displayHigh > MINIMAL_VALUE ? displayHigh : max;
     }
 
     private int translateY(double y) {


### PR DESCRIPTION
In order to find maximal value in data series, 'max' should be initialized with guard value - the least possible value. Unfortunately, it's been initialized with Double.MIN_VALUE, which is positive number, so series with purely negative values are handled improperly.

Moreover, I've extracted 'effective[Min|Max]' methods to DRY code a bit and introduced similar changes - removing usages of Double.MIN_VALUE. Still, comparisons appear to be always true.

Works correctly for:
* min: -94; max: 10; series: -93.0, -95.0, Double.MAX_VALUE, -95.0, -95.0, 20.0, 8.0, -95.0, -91.0, -(Double.MAX_VALUE - 1), -91.0, -95.0, -115.0, -92.0, -93.0, -95.0, -95.0
* min: -94; max: -92; series: -93.0, -94.0, -95.0, -92.0

